### PR TITLE
displaynames added

### DIFF
--- a/BoneCP extension/plugin.json
+++ b/BoneCP extension/plugin.json
@@ -11,6 +11,7 @@
     {
       "timeseries": {
         "key": "TotalCreatedConnections",
+        "displayname": "Total Created Connections",
         "unit": "Count",
         "dimensions": [
           "rx_pid"
@@ -31,6 +32,7 @@
     {
       "timeseries": {
         "key": "TotalLeased",
+        "displayname" : "Total Leased",
         "unit": "Count",
         "dimensions": [
           "rx_pid"
@@ -51,6 +53,7 @@
     {
       "timeseries": {
         "key": "ConnectionsRequested",
+        "displayname" : "Connections Requested",
         "unit": "Count",
         "dimensions": [
           "rx_pid"

--- a/MongoDB extension/plugin.json
+++ b/MongoDB extension/plugin.json
@@ -11,6 +11,7 @@
     {
       "timeseries": {
         "key": "CheckedOutCount",
+        "displayname" : "Checked Out Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -40,6 +41,7 @@
     {
       "timeseries": {
         "key": "MaxSize",
+        "displayname" : "Max Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -69,6 +71,7 @@
     {
       "timeseries": {
         "key": "Size",
+        "displayname" : "Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -98,6 +101,7 @@
     {
       "timeseries": {
         "key": "WaitQueueSize",
+        "displayname" : "Wait Queue Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",

--- a/Netflix OSS extensions/plugin.json
+++ b/Netflix OSS extensions/plugin.json
@@ -12,6 +12,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient_Failed",
+                "displayname" : "Discovery Client Failed",
                 "unit": "Count",
                 "dimensions": ["rx_pid"]
             },
@@ -32,6 +33,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient_Reregister",
+                "displayname" : "Discovery Client Reregister",
                 "unit": "Count",
                 "dimensions": ["rx_pid"]
             },
@@ -52,6 +54,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient_Retry",
+                "displayname" : "Discovery Client Retry",
                 "unit": "Count",
                 "dimensions": ["rx_pid"]
             },
@@ -72,6 +75,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient-HTTPClient_RequestConnectionTimer_count",
+                "displayname" : "DiscoveryClient - HTTPClient RequestConnectionTimer count",
                 "unit": "Count",
                 "dimensions": ["rx_pid"]
             },
@@ -94,6 +98,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient-HTTPClient_RequestConnectionTimer_max",
+                "displayname" : "DiscoveryClient - HTTPClient RequestConnectionTimer max",
                 "unit": "MilliSecond",
                 "dimensions": ["rx_pid"]
             },
@@ -116,6 +121,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient-HTTPClient_RequestConnectionTimer_min",
+                "displayname" : "DiscoveryClient - HTTPClient RequestConnectionTimer min",
                 "unit": "MilliSecond",
                 "dimensions": ["rx_pid"]
             },
@@ -138,6 +144,7 @@
         {
             "timeseries": {
                 "key": "DiscoveryClient-HTTPClient_RequestConnectionTimer_totalTime",
+                "displayname" : "DiscoveryClient - HTTPClient RequestConnectionTimer totalTime",
                 "unit": "MilliSecond",
                 "dimensions": ["rx_pid"]
             },
@@ -160,6 +167,7 @@
         {
             "timeseries": {
                 "key": "ZoneStats_CircuitBreakerTrippedCount",
+                "displayname" : "Zone Stats Circuit Breaker Tripped Count",
                 "unit": "Count",
                 "dimensions": ["rx_pid", "id"]
             },
@@ -187,6 +195,7 @@
         {
             "timeseries": {
                 "key": "ZoneStats_InstanceCount",
+                "displayname" : "Zone Stats Instance Count",
                 "unit": "Count",
                 "dimensions": ["rx_pid", "id"]
             },

--- a/Ruxit built-in extensions/ruxit.jmx.appserver.jetty/plugin.json
+++ b/Ruxit built-in extensions/ruxit.jmx.appserver.jetty/plugin.json
@@ -10,6 +10,7 @@
       "timeseries" :
       {
         "key" : "busyThreads",
+        "displayname" : "busy Threads",
         "unit" : "Count",
         "dimensions" : [
           "rx_pid"
@@ -32,6 +33,7 @@
       "timeseries" :
       {
         "key" : "idleThreads",
+        "displayname" : "idle Threads",
         "unit" : "Count",
         "dimensions" : [
           "rx_pid"
@@ -53,6 +55,7 @@
     {
       "timeseries": {
         "key": "queueSize",
+        "displayname" : "queue Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid"
@@ -74,6 +77,7 @@
     {
       "timeseries": {
         "key": "requestCount",
+        "displayname" : "request Count",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -95,6 +99,7 @@
     {
       "timeseries": {
         "key": "responsesBytesTotal",
+        "displayname" : "responses Bytes Total",
         "unit": "BytePerSecond",
         "dimensions": [
           "rx_pid"
@@ -116,6 +121,7 @@
     {
       "timeseries": {
         "key": "connections",
+        "displayname" : "connections",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -138,6 +144,7 @@
     {
       "timeseries": {
         "key": "connectionsOpen",
+        "displayname" : "connections Open",
         "unit": "Count",
         "dimensions": [
           "rx_pid"

--- a/Ruxit built-in extensions/ruxit.jmx.appserver/plugin.json
+++ b/Ruxit built-in extensions/ruxit.jmx.appserver/plugin.json
@@ -10,6 +10,7 @@
       "timeseries" :
       {
         "key" : "tomcat.currentThreadsBusy",
+        "displayname" : "tomcat current Threads Busy",
         "unit" : "Count",
         "dimensions" : [
           "rx_pid",
@@ -22,6 +23,7 @@
       "timeseries" :
       {
         "key" : "tomcat.currentThreadsIdle",
+        "displayname" : "tomcat current Threads Idle",
         "unit" : "Count",
         "dimensions" : [
           "rx_pid",
@@ -34,6 +36,7 @@
       "timeseries" :
       {
         "key" : "tomcat.bytesReceivedPerSecond",
+        "displayname" : "tomcat bytes Received Per Second",
         "unit" : "BytePerSecond",
         "dimensions" : [
           "rx_pid",
@@ -46,6 +49,7 @@
       "timeseries" :
       {
         "key" : "tomcat.bytesSentPerSecond",
+        "displayname" : "tomcat bytes Sent Per Second",
         "unit" : "BytePerSecond",
         "dimensions" : [
           "rx_pid",
@@ -58,6 +62,7 @@
       "timeseries" :
       {
         "key" : "tomcat.requestCountPerSecond",
+        "displayname" : "tomcat request Count Per Second",
         "unit" : "PerSecond",
         "dimensions" : [
           "rx_pid",

--- a/Ruxit built-in extensions/ruxit.jmx.hornetq/plugin.json
+++ b/Ruxit built-in extensions/ruxit.jmx.hornetq/plugin.json
@@ -18,6 +18,7 @@
         {
             "timeseries": {
                 "key": "Queue.ConsumerCount",
+                "displayname" : "Queue Consumer Count",
                 "unit": "Count",
                 "dimensions": [
                     "rx_pid",
@@ -46,6 +47,7 @@
         {
             "timeseries": {
                 "key": "Queue.MessageCount",
+                "displayname" : "Queue Message Count",
                 "unit": "Count",
                 "dimensions": [
                     "rx_pid",
@@ -74,6 +76,7 @@
         {
             "timeseries": {
                 "key": "Queue.ScheduledCount",
+                "displayname" : "Queue Scheduled Count",
                 "unit": "Count",
                 "dimensions": [
                     "rx_pid",
@@ -102,6 +105,7 @@
         {
             "timeseries": {
                 "key": "Queue.DeliveringCount",
+                "displayname" : "Queue Delivering Count",
                 "unit": "Count",
                 "dimensions": [
                     "rx_pid",
@@ -130,6 +134,7 @@
         {
             "timeseries": {
                 "key": "Queue.MessagesAdded",
+                "displayname" : "Queue Messages Added",
                 "unit": "Count",
                 "dimensions": [
                     "rx_pid",

--- a/Ruxit built-in extensions/ruxit.jmx.solr/plugin.json
+++ b/Ruxit built-in extensions/ruxit.jmx.solr/plugin.json
@@ -13,6 +13,7 @@
 	{
 		"timeseries": {
 			"key": "searcher.deletedDocs",
+			"displayname" : "searcher deleted Docs",
 			"unit": "Count",
 			"dimensions": ["rx_pid"]
 		},
@@ -32,6 +33,7 @@
 	{
 		"timeseries": {
 			"key": "searcher.maxDoc",
+			"displayname" : "searcher max Doc",
 			"unit": "Count",
 			"dimensions": ["rx_pid"]
 		},
@@ -51,6 +53,7 @@
 	{
 		"timeseries": {
 			"key": "searcher.numDocs",
+			"displayname": "searcher num Docs",
 			"unit": "Count",
 			"dimensions": ["rx_pid"]
 		},
@@ -70,6 +73,7 @@
     {
       "timeseries": {
         "key": "update.adds",
+        "displayname": "update adds",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -91,6 +95,7 @@
     {
       "timeseries": {
         "key": "update.deletesById",
+        "displayname": "update deletes By Id",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -112,6 +117,7 @@
     {
       "timeseries": {
         "key": "update.deletesByQuery",
+        "displayname": "update deletes By Query",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -133,6 +139,7 @@
     {
       "timeseries": {
         "key": "update.errors",
+        "displayname": "update errors",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"
@@ -154,6 +161,7 @@
 	{
 		"timeseries": {
 			"key": "documentCache.evictions",
+			"displayname": "document Cache evictions",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -173,6 +181,7 @@
 	{
 		"timeseries": {
 			"key": "documentCache.hits",
+			"displayname": "document Cache hits",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -192,6 +201,7 @@
 	{
 		"timeseries": {
 			"key": "documentCache.inserts",
+			"displayname": "document Cache inserts",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -211,6 +221,7 @@
 	{
 		"timeseries": {
 			"key": "documentCache.lookups",
+			"displayname": "document Cache lookups",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -230,6 +241,7 @@
 	{
 		"timeseries": {
 			"key": "queryResultCache.evictions",
+			"displayname": "query Result Cache evictions",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -249,6 +261,7 @@
 	{
 		"timeseries": {
 			"key": "queryResultCache.hits",
+			"displayname": "query Result Cache hits",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -268,6 +281,7 @@
 	{
 		"timeseries": {
 			"key": "queryResultCache.inserts",
+			"displayname": "query Result Cache inserts",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -287,6 +301,7 @@
 	{
 		"timeseries": {
 			"key": "queryResultCache.lookups",
+			"displayname": "query Result Cache lookups",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -306,6 +321,7 @@
 	{
 		"timeseries": {
 			"key": "filterCache.evictions",
+			"displayname": "filter Cache evictions",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -325,6 +341,7 @@
 	{
 		"timeseries": {
 			"key": "filterCache.hits",
+			"displayname": "filterCache hits",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -344,6 +361,7 @@
 	{
 		"timeseries": {
 			"key": "filterCache.inserts",
+			"displayname": "filter Cache inserts",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -363,6 +381,7 @@
 	{
 		"timeseries": {
 			"key": "filterCache.lookups",
+			"displayname": "filter Cache lookups",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -382,6 +401,7 @@
 	{
 		"timeseries": {
 			"key": "fieldValueCache.evictions",
+			"displayname": "field Value Cache evictions",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -401,6 +421,7 @@
 	{
 		"timeseries": {
 			"key": "fieldValueCache.hits",
+			"displayname": "field Value Cache hits",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -420,6 +441,7 @@
 	{
 		"timeseries": {
 			"key": "fieldValueCache.inserts",
+			"displayname": "field Value Cache inserts",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -439,6 +461,7 @@
 	{
 		"timeseries": {
 			"key": "fieldValueCache.lookups",
+			"displayname": "field Value Cache lookups",
 			"unit": "PerSecond",
 			"dimensions": ["rx_pid"]
 		},
@@ -458,6 +481,7 @@
     {
       "timeseries": {
         "key": "select.requests",
+        "displayname": "select requests",
         "unit": "PerSecond",
         "dimensions": [
           "rx_pid"

--- a/Tomcat JDBC ext/plugin.json
+++ b/Tomcat JDBC ext/plugin.json
@@ -12,7 +12,7 @@
       "timeseries": {
         "key": "Size",
         "unit": "Count",
-	"displayname": "Size",
+	      "displayname": "Size",
         "dimensions": [
           "rx_pid"
         ]
@@ -34,7 +34,7 @@
       "timeseries": {
         "key": "MaxActive",
         "unit": "Count",
-	"displayname": "MaxActive",
+	      "displayname": "MaxActive",
         "dimensions": [
           "rx_pid"
         ]
@@ -56,7 +56,7 @@
       "timeseries": {
         "key": "Active",
         "unit": "Count",
-	"displayname": "Active",
+	      "displayname": "Active",
         "dimensions": [
           "rx_pid"
         ]

--- a/c3p0 extension/plugin.json
+++ b/c3p0 extension/plugin.json
@@ -11,6 +11,7 @@
     {
       "timeseries": {
         "key": "maxPoolSize",
+        "displayname" : "max Pool Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -37,6 +38,7 @@
     {
       "timeseries": {
         "key": "numConnections",
+        "displayname" : "num Connections",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -63,6 +65,7 @@
     {
       "timeseries": {
         "key": "numBusyConnections",
+        "displayname" : "num Busy Connections",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -89,6 +92,7 @@
     {
       "timeseries": {
         "key": "numUnclosedOrphanedConnections",
+        "displayname" : "num Unclosed Orphaned Connections",
         "unit": "Count",
         "dimensions": [
           "rx_pid",

--- a/unfinished extensions/ActiveMQ/plugin.json
+++ b/unfinished extensions/ActiveMQ/plugin.json
@@ -11,6 +11,7 @@
     {
       "timeseries": {
         "key": "Topic.AverageMessageSize",
+        "displayname" : "Topic Average Message Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -40,6 +41,7 @@
     {
       "timeseries": {
         "key": "Topic.ConsumerCount",
+        "displayname" : "Topic Consumer Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -69,6 +71,7 @@
     {
       "timeseries": {
         "key": "DequeueCount",
+        "displayname" : "Dequeue Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -98,6 +101,7 @@
     {
       "timeseries": {
         "key": "DispatchCount",
+        "displayname" : "Dispatch Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -127,6 +131,7 @@
     {
       "timeseries": {
         "key": "EnqueueCount",
+        "displayname" : "Enqueue Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -156,6 +161,7 @@
     {
       "timeseries": {
         "key": "InFlightCount",
+        "displayname" : "In Flight Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -185,6 +191,7 @@
     {
       "timeseries": {
         "key": "ExpiredCount",
+        "displayname" : "Expired Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -214,6 +221,7 @@
     {
       "timeseries": {
         "key": "ProducerCount",
+        "displayname" : "Producer Count",
         "unit": "Count",
         "dimensions": [
           "rx_pid",
@@ -243,6 +251,7 @@
     {
       "timeseries": {
         "key": "QueueSize",
+        "displayname" : "Queue Size",
         "unit": "Count",
         "dimensions": [
           "rx_pid",


### PR DESCRIPTION
Since last year Dynatrace requires that plugin timeseries have display name defined. Without it Dynatrace will not accept whole plugin.
Now plugin exaples have updated displayname field in timeseries declaration.